### PR TITLE
Chained commands with children will now print options

### DIFF
--- a/ishell/command.py
+++ b/ishell/command.py
@@ -110,7 +110,10 @@ class Command(Console):
         return completions[state]
 
     def run(self, line):
-        _print("Exec %s(line=%s), overwrite this method!" % (self.name, line))
+        if self.childs:
+            _print("Options: %s" % ', '.join(self.childs.keys()))
+        else:
+            _print("Exec %s(line=%s), overwrite this method!" % (self.name, line))
 
     def __repr__(self):
         return "<Command:(%s), Childs(%s)>" % (self.name, "-".join(self.childs))


### PR DESCRIPTION
Quick fix to allow the user to hit enter on the parent of a chained command and see the child options. For example, if: 

```
showcmd = console.addChild(Command('show'))
showcmd.addChild(Command('disk')).addChild(DiskIO('io'))
showcmd.addChild(Command('network')).addChild(DiskIO('io'))
```

then:

```
> show [RET]
Options: disk, network
```

Fixes #12
