### PR TITLE
Solving readline installation problem and 'builtins' ImportError

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-readline
+gnureadline
+future

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
         'License :: OSI Approved :: MIT License',
     ],
     install_requires=[
-        "readline",
+        "gnureadline",
+        "future"
     ]
 )


### PR DESCRIPTION
Tests are passing:
```
$ python test_shell.py 
Possible Completions:
  call            No help provided
  calls           No help provided
Possible Completions:
  interface       No help provided
  terminal        No help provided
None....
----------------------------------------------------------------------
Ran 7 tests in 0.002s

OK
```
Examples are running:
```
$ python examples/linux_shell.py 
root@dev:~# ls
examples  ishell  ishell.egg-info  LICENSE.txt	README.md  requirements.txt  setup.py  test_py3.py  test_shell.py
```