### PR TITLE
Implemented show help on ? key press

### DIFF
--- a/ishell/command.py
+++ b/ishell/command.py
@@ -111,7 +111,8 @@ class Command(Console):
             _print("Exec %s(line=%s), overwrite this method!" % (self.name, line))
             return
 
-        print("\nIncomplete Command: %s\n" % line)
+        if len(str(line)) > 0 and line[-1] != "?":
+            print("\nIncomplete Command: %s\n" % line)
         self.print_childs_help()
 
     def __repr__(self):


### PR DESCRIPTION
Fixes #16 

I added this feature by using gnu readline's bind feature to map ? to press Enter. But I needed to differentiate normal Enter and ? Enter, so that I can reprint previous command in case of ?. So I mapped ? to some random string(which most probably won't be used in any command).

One problem with this feature is, it won't let us use ? in commands. I minimized this by showing help only when ? has space or no character before it.

Sample output:
```
root@dev:~# ?
Help:
           bash - No help provided
             ls - No help provided
           show - No help provided
            top - No help provided
root@dev:~# show ?
Help:
           disk - No help provided
root@dev:~# show 
```

I hope this solves the issue for you.

Also, I have no idea how we should test this feature. Can you provide me some insights on it?