### PR TITLE
Add Windows support using conditional dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,15 @@
 
 import ishell
 from setuptools import setup, find_packages
+from sys import platform
 
+# If we're on Windows, use pyreadline instead of gnureadline
+if platform == 'win32':
+    requires_file = 'win_requirements.txt'
+else:
+    requires_file = 'requirements.txt'
 
-with open('requirements.txt') as f:
+with open(requires_file) as f:
     requires = f.readlines()
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from ishell import __version__ as ishell_version
 from setuptools import setup, find_packages
 from sys import platform
 
@@ -14,6 +13,7 @@ else:
 with open(requires_file) as f:
     requires = f.readlines()
 
+ishell_version = "0.1.5"
 
 setup(
     name='ishell',

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import ishell
 from setuptools import setup, find_packages
 from sys import platform
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from ishell import __version__ as ishell_version
 from setuptools import setup, find_packages
 from sys import platform
 
@@ -16,7 +17,7 @@ with open(requires_file) as f:
 
 setup(
     name='ishell',
-    version=ishell.__version__,
+    version=ishell_version,
     author=u'Ítalo Rossi',
     author_email='italorossib@gmail.com',
     description='Build Interactive Shells with Python',

--- a/win_requirements.txt
+++ b/win_requirements.txt
@@ -1,0 +1,2 @@
+pyreadline
+future


### PR DESCRIPTION
Since I want to allow FeatherDuster to work on Windows and it relies on `ishell`, I have changed the dependencies of `ishell` to be conditional: On Windows platforms, it installs `pyreadline`. On others, it defaults to `gnureadline`.

Also, during install, `ishell` currently imports `ishell` in order to pull the version number. Unfortunately, the `ishell` module included in the repo imports `readline` before installing any `readline` module. On Mac OS and Linux this is fine since their distributions come with a built in `readline` module. On Windows, the install can never succeed unless the user has already installed `pyreadline`.

It's not ideal, but I've put the version number of `ishell` in the `setup.py` file so that you don't need to import the module you're attempting to install the dependencies for, causing a catch 22 situation on Windows.

Let me know if you'd like to handle this situation differently, or if you wish to not support Windows at all.

Thanks!